### PR TITLE
Fix code scanning alert no. 10: Incomplete string escaping or encoding

### DIFF
--- a/randomize.ts
+++ b/randomize.ts
@@ -199,7 +199,7 @@ export function UpdateImports() {
 
       OriginalPatterns.forEach((pattern, index) => {
         content = content.replace(
-          new RegExp(`['"]${pattern.replace(/\./g, "\\.")}['"]`, "g"),
+          new RegExp(`['"]${pattern.replace(/\\/g, "\\\\").replace(/\./g, "\\.")}['"]`, "g"),
           `'${NewPatterns[index]}'`,
         );
       });


### PR DESCRIPTION
Fixes [https://github.com/UseInterstellar/Interstellar-Astro/security/code-scanning/10](https://github.com/UseInterstellar/Interstellar-Astro/security/code-scanning/10)

To fix the problem, we need to ensure that backslashes in the `pattern` string are properly escaped before using it in a regular expression. This can be done by replacing each backslash with a double backslash. We will modify the `pattern.replace` call to include this additional escaping step.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
