### PR TITLE
Fix code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/src/lib/global.ts
+++ b/src/lib/global.ts
@@ -89,7 +89,12 @@ document.addEventListener("astro:page-load", () => {
 document.addEventListener("astro:page-load", () => {
   const Key = localStorage.getItem("key") || "";
   const PanicKeys = Key.split(",").map((key) => key.trim());
-  const PanicLink = localStorage.getItem("link") || "";
+  let PanicLink = localStorage.getItem("link") || "";
+  try {
+    PanicLink = new URL(PanicLink).toString();
+  } catch (e) {
+    PanicLink = "";
+  }
   let Typed: string[] = [];
   let Shift = false;
 


### PR DESCRIPTION
Fixes [https://github.com/UseInterstellar/Interstellar-Astro/security/code-scanning/4](https://github.com/UseInterstellar/Interstellar-Astro/security/code-scanning/4)

To fix the problem, we need to ensure that the `PanicLink` is properly sanitized before being used to set `window.location.href`. This can be achieved by validating the URL to ensure it is a safe and expected value. We can use a regular expression to validate the URL format or use the `URL` constructor to parse and validate the URL.

The best way to fix the problem without changing existing functionality is to add a validation step before setting `window.location.href`. We will use the `URL` constructor to ensure the `PanicLink` is a valid URL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
