### PR TITLE
Fix code scanning alert no. 9: DOM text reinterpreted as HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "tailwindcss": "^3.4.13",
     "tsx": "^4.19.2",
     "typescript": "^5.6.3",
-    "vite-plugin-static-copy": "^2.1.0"
+    "vite-plugin-static-copy": "^2.1.0",
+    "dompurify": "^3.2.1"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.3",

--- a/src/lib/global.ts
+++ b/src/lib/global.ts
@@ -1,7 +1,9 @@
+import DOMPurify from 'dompurify';
+
 document.addEventListener("astro:page-load", () => {
   // Cloak
   document.title = localStorage.getItem("title") ?? "Home";
-  const icon = localStorage.getItem("icon") ?? "/assets/media/favicons/default.png";
+  const icon = DOMPurify.sanitize(localStorage.getItem("icon") ?? "/assets/media/favicons/default.png");
   const iconElm = document.getElementById("icon");
   if (iconElm) (iconElm as HTMLLinkElement).href = icon;
 


### PR DESCRIPTION
Fixes [https://github.com/UseInterstellar/Interstellar-Astro/security/code-scanning/9](https://github.com/UseInterstellar/Interstellar-Astro/security/code-scanning/9)

To fix the problem, we need to ensure that the value retrieved from `localStorage` is properly sanitized before being used in the DOM. One way to achieve this is by using a library like `DOMPurify` to sanitize the value. This will prevent any malicious content from being executed as HTML.

- Import the `DOMPurify` library.
- Sanitize the `icon` value retrieved from `localStorage` before assigning it to the `href` attribute of the HTML element.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
