### PR TITLE
Fix code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/src/lib/global.ts
+++ b/src/lib/global.ts
@@ -94,6 +94,7 @@ document.addEventListener("astro:page-load", () => {
   let PanicLink = localStorage.getItem("link") || "";
   try {
     PanicLink = new URL(PanicLink).toString();
+    PanicLink = DOMPurify.sanitize(PanicLink);
   } catch (e) {
     PanicLink = "";
   }


### PR DESCRIPTION
Fixes [https://github.com/UseInterstellar/Interstellar-Astro/security/code-scanning/4](https://github.com/UseInterstellar/Interstellar-Astro/security/code-scanning/4)

To fix the problem, we need to ensure that the `PanicLink` value is properly sanitized before being used to set `window.location.href`. We can use the `DOMPurify` library to sanitize the `PanicLink` value, ensuring that any potentially malicious content is removed.

- Import the `DOMPurify` library if not already imported.
- Sanitize the `PanicLink` value using `DOMPurify.sanitize` before using it to set `window.location.href`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
