### PR TITLE
Potential fix for code scanning alert no. 12: DOM text reinterpreted as HTML

### DIFF
--- a/src/components/Browser.tsx
+++ b/src/components/Browser.tsx
@@ -1,6 +1,6 @@
 import { ChevronLeft, ChevronRight, Home, Lock, Maximize2, Menu, MoreVertical, Plus, RotateCw, Star, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { actionBarClass, addressInputClass, classNames, closeButtonClass, encodeProxyUrl, formatUrl, getActualUrl, getDefaultUrl, type Tab, tabButtonClass } from "@/lib/tabs";
+import { actionBarClass, addressInputClass, classNames, closeButtonClass, encodeProxyUrl, formatUrl, getActualUrl, getDefaultUrl, type Tab, tabButtonClass, sanitizeUrl } from "@/lib/tabs";
 
 const IconButton = ({ onClick, icon: Icon, className = "", disabled = false, title = "" }: { onClick?: () => void; icon: React.ComponentType<{ className?: string }>; className?: string; disabled?: boolean; title?: string }) => (
   <button
@@ -450,7 +450,7 @@ export default function Browser() {
               iframeRefs.current[tab.id] = el;
             }}
             title={tab.title}
-            src={encodeProxyUrl(tab.url)}
+            src={encodeProxyUrl(sanitizeUrl(tab.url))}
             className={classNames("absolute inset-0 h-full w-full border-0", tab.active ? "block" : "hidden")}
             sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox"
           />

--- a/src/lib/tabs.ts
+++ b/src/lib/tabs.ts
@@ -46,6 +46,21 @@ export const getDefaultUrl = () => {
   }
 };
 
+// Only allow 'about:blank' and HTTP(S) URLs. All others are replaced with 'about:blank'.
+export function sanitizeUrl(url: string): string {
+  if (!url || url === "about:blank") return "about:blank";
+  try {
+    // This throws for invalid URLs, so fallback to 'about:blank'
+    const parsed = new URL(url, "https://example.com");
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return parsed.href;
+    }
+  } catch {
+    // Malformed URL, fallback
+  }
+  return "about:blank";
+}
+
 export const encodeProxyUrl = (url: string): string => {
   if (!url || url === "about:blank") return "about:blank";
   if (typeof window === "undefined") return url;


### PR DESCRIPTION
Potential fix for [https://github.com/UseInterstellar/Interstellar-Astro/security/code-scanning/12](https://github.com/UseInterstellar/Interstellar-Astro/security/code-scanning/12)

To fully address this vulnerability, the user-supplied URL (flowing from search input and settings) **must be validated and sanitized such that only safe schemes like `https://` or `http://` are allowed** before being rendered as an iframe `src`. There are two robust ways to do this:

1. **Sanitize at Input Time:**  
   Validate user input as soon as it's received and before storing it into storage.
2. **Sanitize at Output Time:**  
   Before assigning to the iframe's `src` prop, ensure it's a valid HTTP(S) URL.

The best place is **before passing to `encodeProxyUrl` in Browser.tsx** (i.e., sanitize every `tab.url` before passing to that function), so that even data from bookmarks or other flows cannot inject a malicious URL into the iframe. This check will ensure only valid HTTP(S) URLs (or `about:blank`) are used.

**Implementation steps:**

- Add a `sanitizeUrl` function (in `src/lib/tabs.ts`), ensuring the input is "about:blank" or a safe HTTP(S) URL, or else default to "about:blank".
- Use this `sanitizeUrl` in Browser.tsx, wrapping the `tab.url` value on line 453 before passing it to `encodeProxyUrl`.
- Consider using the browser-provided `URL` constructor for parsing, or a regex matching HTTP(S) URLs.  
- No new dependencies are strictly needed for this simple filter.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
